### PR TITLE
Hide "mastersegment" type tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## 1.1.1
+
+### New features
+
+- Add parent ID when test has one
+
+### Updates
+
+- Hide tests with type `mastersegment` in the list
+
 ## 1.1.0
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Updates
 
-- Hide tests with type `mastersegment` in the list
+- Hide tests with type `mastersegment` in the list and the badge counter
 
 ## 1.1.0
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AB Tasty Debugger
 
-![ABTastyDebugger](https://img.shields.io/badge/abtasty--debugger-v1.1.0-009CB2.svg?style=for-the-badge) ![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/yoriiis/abtasty-debugger/Build/main?style=for-the-badge) [![Coverage Status](https://img.shields.io/coveralls/github/yoriiis/abtasty-debugger?style=for-the-badge)](https://coveralls.io/github/yoriiis/abtasty-debugger?branch=main)
+![ABTastyDebugger](https://img.shields.io/badge/abtasty--debugger-v1.1.1-009CB2.svg?style=for-the-badge) ![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/yoriiis/abtasty-debugger/Build/main?style=for-the-badge) [![Coverage Status](https://img.shields.io/coveralls/github/yoriiis/abtasty-debugger?style=for-the-badge)](https://coveralls.io/github/yoriiis/abtasty-debugger?branch=main)
 
 `AB Tasty Debugger` is a browser extension that simplifies the debugging of A/B Tests from AB Tasty and adds useful informations.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "abtasty-debugger",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "Browser extension that simplifies the debugging of A/B tests from AB Tasty and adds useful informations",
 	"homepage": "https://github.com/yoriiis/abtasty-debugger",
 	"bugs": "https://github.com/yoriiis/abtasty-debugger/issues",

--- a/src/popup/assets/scripts/popup.tsx
+++ b/src/popup/assets/scripts/popup.tsx
@@ -10,7 +10,7 @@ export default class Popup {
 	router: any;
 	instances: Array<any>;
 	instancesResult: Array<any>;
-    formattedData: null | FormattedData;
+	formattedData: null | FormattedData;
 	routes: {
 		[key: string]: {
 			path: string;

--- a/src/popup/components/detail/assets/scripts/detail.tsx
+++ b/src/popup/components/detail/assets/scripts/detail.tsx
@@ -35,6 +35,7 @@ export default class Detail {
 
 		return {
 			testId,
+			test: data.accountData.tests[testId],
 			result: data.results[testId],
 			targetingSorted: formattedData.targetingsSortedByStatus[testId],
 			targetingMode: data.accountData.tests[testId].targetingMode

--- a/src/popup/components/detail/assets/scripts/templates/detail.tsx
+++ b/src/popup/components/detail/assets/scripts/templates/detail.tsx
@@ -36,12 +36,15 @@ export default function ({ data }: {data: DetailData}) {
 			</ul>
 			<ul className="detail-list">
 				<li>Name: {data.result.name}</li>
-				<li>ID: {data.testId}</li>
+				<li>
+                    ID: {data.testId}
+					{data.test.parentID !== 0 && <> (parent ID: {data.test.parentID})</>}
+				</li>
 				<li>Type: {data.result.type}</li>
 				{data.result.variationName && (
 					<li>
-							Variation: {data.result.variationName}{' '}
-						{data.result.variationID && <>({data.result.variationID})</>}
+						Variation: {data.result.variationName}
+						{data.result.variationID && <> ({data.result.variationID})</>}
 					</li>
 				)}
 				<li>Ajax targeting: {data.targetingMode === 'waituntil' ? 'on' : 'off'}</li>

--- a/src/popup/components/detail/assets/scripts/templates/detail.tsx
+++ b/src/popup/components/detail/assets/scripts/templates/detail.tsx
@@ -37,7 +37,7 @@ export default function ({ data }: {data: DetailData}) {
 			<ul className="detail-list">
 				<li>Name: {data.result.name}</li>
 				<li>
-                    ID: {data.testId}
+					ID: {data.testId}
 					{data.test.parentID !== 0 && <> (parent ID: {data.test.parentID})</>}
 				</li>
 				<li>Type: {data.result.type}</li>

--- a/src/shared/assets/content-scripts/content-script.js
+++ b/src/shared/assets/content-scripts/content-script.js
@@ -10,13 +10,17 @@ let dataFromPage
 // Listen for event from the page script
 document.addEventListener('sendABTastyObject', (event) => {
 	const data = JSON.parse(event.detail.ABTastyData)
-
 	dataFromPage = data
+
+	// Calculate the counter excluding "mastersegment" type tests
+	const counter = Object.keys(data.results).filter(
+		(key) => data.results[key].type !== 'mastersegment'
+	).length
 
 	namespace.runtime.sendMessage({
 		from: 'contentScript',
 		action: 'updateBadge',
-		counter: Object.keys(data.results).length
+		counter
 	})
 })
 

--- a/src/shared/assets/fixtures/abtasty.json
+++ b/src/shared/assets/fixtures/abtasty.json
@@ -1,16 +1,30 @@
 {
 	"accountData": {
 		"tests": {
-			"000001": {
-				"targetingMode": "waituntil"
+			"900001": {
+				"id": 900001,
+				"targetingMode": "waituntil",
+				"parentID": 0
 			},
-			"000002": {
-				"targetingMode": "fastest"
+			"900002": {
+				"id": 900002,
+				"targetingMode": "fastest",
+				"parentID": 0
+			},
+			"900003": {
+				"id": 900003,
+				"targetingMode": "fastest",
+				"parentID": 0
+			},
+			"900004": {
+				"id": 900004,
+				"targetingMode": "fastest",
+				"parentID": 900003
 			}
 		}
 	},
 	"results": {
-		"000001": {
+		"900001": {
 			"name": "Test with the menu button on the left",
 			"type": "ab",
 			"status": "accepted",
@@ -32,11 +46,11 @@
 				"qaParameters": {}
 			}
 		},
-		"000002": {
+		"900002": {
 			"name": "Test with darkmode sticky banner on the header",
 			"type": "ab",
 			"status": "rejected",
-			"variationID": "001001",
+			"variationID": 901001,
 			"variationName": "header-darkmode-cta",
 			"targetings": {
 				"targetPages": {
@@ -97,6 +111,57 @@
 						"success": true
 					}
 				}
+			}
+		},
+		"900003": {
+			"name": "Satisfaction survey",
+			"type": "mastersegment",
+			"status": "master_campaign_not_checked",
+			"variationID": null,
+			"variationName": null,
+			"targetings": {
+				"targetPages": {},
+				"qaParameters": {}
+			}
+		},
+		"900004": {
+			"name": "Scenario satisfaction survey",
+			"type": "subsegment",
+			"status": "pending",
+			"variationID": null,
+			"variationName": null,
+			"targetings": {
+				"targetPages": {
+					"url_scope": {
+						"conditions": [
+							{
+								"include": false,
+								"condition": 10,
+								"value": "https://www.programme-tv.net"
+							}
+						],
+						"success": true
+					},
+					"code_scope": {
+						"conditions": [
+							{
+								"value": "var hourStart = 18;\nvar hourEnd = 4;\nvar hourGranted = new Date().getHours() >= hourStart || new Date().getHours() <= hourEnd;\n\nif (hourGranted) {\n    return true;\n} else {\n    return false;\n}"
+							}
+						],
+						"success": true
+					},
+					"selector_scope": {
+						"conditions": [
+							{
+								"include": true,
+								"condition": 44,
+								"value": ".footer"
+							}
+						],
+						"success": false
+					}
+				},
+				"qaParameters": {}
 			}
 		}
 	},

--- a/src/shared/assets/interfaces/interfaces.ts
+++ b/src/shared/assets/interfaces/interfaces.ts
@@ -1,8 +1,8 @@
 export interface Condition {
-    name?: string;
-    value: string;
-    include: Boolean;
-    condition: Number;
+	name?: string;
+	value: string;
+	include: Boolean;
+	condition: Number;
 }
 
 export interface Targeting {
@@ -16,9 +16,9 @@ export interface Result {
 	name: string;
 	type: string;
 	status: string;
-    targetingMode: string;
-    variationID: Number;
-    variationName: string;
+	targetingMode: string;
+	variationID: Number;
+	variationName: string;
 	targetings: {
 		targetPages: {
 			[key: string]: Targeting;
@@ -31,18 +31,18 @@ export interface Result {
 
 export interface Test {
 	id: Number;
-    targetingMode: string;
-    parentID: Number;
+	targetingMode: string;
+	parentID: Number;
 }
 
 export interface Data {
-    accountData: {
-        tests:{
-            [key: string]: {
-                targetingMode: string;
-            };
-        }
-    };
+	accountData: {
+		tests:{
+			[key: string]: {
+				targetingMode: string;
+			};
+		}
+	};
 	results: {
 		[key: string]: Result;
 	}
@@ -54,8 +54,8 @@ export interface TestsSortedByStatus {
 }
 
 export interface TargetingItemSortedByStatus {
-    accepted: Array<Targeting>;
-    rejected: Array<Targeting>;
+	accepted: Array<Targeting>;
+	rejected: Array<Targeting>;
 }
 
 export interface TargetingsSortedByStatus {
@@ -63,30 +63,30 @@ export interface TargetingsSortedByStatus {
 }
 
 export interface CustomEvent {
-    detail: Object;
+	detail: Object;
 }
 
 export interface Wording {
-    [key: string]: string;
+	[key: string]: string;
 }
 
 export interface DetailData {
-    testId: string;
-    test: Test;
-    result: Result;
-    targetingSorted: TargetingItemSortedByStatus;
-    targetingMode: string
+	testId: string;
+	test: Test;
+	result: Result;
+	targetingSorted: TargetingItemSortedByStatus;
+	targetingMode: string
 }
 
 export interface DynamicSegments {
-    [key: string]: string;
+	[key: string]: string;
 }
 
 export interface ListData {
-    testsSortedByStatus: TestsSortedByStatus;
+	testsSortedByStatus: TestsSortedByStatus;
 }
 
 export interface FormattedData {
-    testsSortedByStatus: TestsSortedByStatus;
-    targetingsSortedByStatus: TargetingsSortedByStatus;
+	testsSortedByStatus: TestsSortedByStatus;
+	targetingsSortedByStatus: TargetingsSortedByStatus;
 }

--- a/src/shared/assets/interfaces/interfaces.ts
+++ b/src/shared/assets/interfaces/interfaces.ts
@@ -10,6 +10,7 @@ export interface Targeting {
 	success: Boolean;
 	conditions: Array<Condition>;
 }
+
 export interface Result {
 	key: string;
 	name: string;
@@ -26,6 +27,12 @@ export interface Result {
 			[key: string]: Targeting;
 		};
 	}
+}
+
+export interface Test {
+	id: Number;
+    targetingMode: string;
+    parentID: Number;
 }
 
 export interface Data {
@@ -65,6 +72,7 @@ export interface Wording {
 
 export interface DetailData {
     testId: string;
+    test: Test;
     result: Result;
     targetingSorted: TargetingItemSortedByStatus;
     targetingMode: string

--- a/src/shared/assets/manifests/manifest-v2.json
+++ b/src/shared/assets/manifests/manifest-v2.json
@@ -2,7 +2,7 @@
 	"manifest_version": 2,
 	"name": "AB Tasty Debugger",
 	"description": "Debug A/B tests from AB Tasty. Open source.",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"permissions": ["http://*/*", "https://*/*"],
 	"icons": {
 		"16": "images/icon-16x16.png",

--- a/src/shared/assets/manifests/manifest-v3.json
+++ b/src/shared/assets/manifests/manifest-v3.json
@@ -2,7 +2,7 @@
 	"manifest_version": 3,
 	"name": "AB Tasty Debugger",
 	"description": "Debug A/B tests from AB Tasty. Open source.",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"icons": {
 		"16": "images/icon-16x16.png",
 		"48": "images/icon-48x48.png",

--- a/src/shared/utils/__tests__/data-manager.test.js
+++ b/src/shared/utils/__tests__/data-manager.test.js
@@ -3,24 +3,35 @@ import fixturesAbtasty from '../../assets/fixtures/abtasty.json'
 
 let dataManager
 const testsSortedByStatus = {
-	accepted: [fixturesAbtasty.results['000001']],
-	rejected: [fixturesAbtasty.results['000002']]
+	accepted: [fixturesAbtasty.results[900001]],
+	rejected: [fixturesAbtasty.results[900002], fixturesAbtasty.results[900004]]
 }
 const targetingsSortedByStatus = {
-	'000001': {
+	900001: {
 		accepted: [],
-		rejected: [fixturesAbtasty.results['000001'].targetings.targetPages.url_scope]
+		rejected: [fixturesAbtasty.results[900001].targetings.targetPages.url_scope]
 	},
-	'000002': {
+	900002: {
 		accepted: [
-			fixturesAbtasty.results['000002'].targetings.targetPages.url_scope,
-			fixturesAbtasty.results['000002'].targetings.targetPages.code_scope,
-			fixturesAbtasty.results['000002'].targetings.qaParameters.ip_scope
+			fixturesAbtasty.results[900002].targetings.targetPages.url_scope,
+			fixturesAbtasty.results[900002].targetings.targetPages.code_scope,
+			fixturesAbtasty.results[900002].targetings.qaParameters.ip_scope
 		],
 		rejected: [
-			fixturesAbtasty.results['000002'].targetings.targetPages.selector_scope,
-			fixturesAbtasty.results['000002'].targetings.qaParameters.cookie_scope
+			fixturesAbtasty.results[900002].targetings.targetPages.selector_scope,
+			fixturesAbtasty.results[900002].targetings.qaParameters.cookie_scope
 		]
+	},
+	900003: {
+		accepted: [],
+		rejected: []
+	},
+	900004: {
+		accepted: [
+			fixturesAbtasty.results[900004].targetings.targetPages.url_scope,
+			fixturesAbtasty.results[900004].targetings.targetPages.code_scope
+		],
+		rejected: [fixturesAbtasty.results[900004].targetings.targetPages.selector_scope]
 	}
 }
 
@@ -30,7 +41,7 @@ beforeEach(() => {
 	dataManager = getInstance()
 })
 
-describe('Router getFormattedData', () => {
+describe('DataManager getFormattedData', () => {
 	it('Should call the getFormattedData function', () => {
 		const result = dataManager.getFormattedData(fixturesAbtasty)
 
@@ -41,7 +52,7 @@ describe('Router getFormattedData', () => {
 	})
 })
 
-describe('Router getTestsSortedByStatus', () => {
+describe('DataManager getTestsSortedByStatus', () => {
 	it('Should call the getTestsSortedByStatus function', () => {
 		const result = dataManager.getTestsSortedByStatus(fixturesAbtasty)
 
@@ -49,7 +60,7 @@ describe('Router getTestsSortedByStatus', () => {
 	})
 })
 
-describe('Router getTargetingsSortedByStatus', () => {
+describe('DataManager getTargetingsSortedByStatus', () => {
 	it('Should call the getTargetingsSortedByStatus function', () => {
 		const result = dataManager.getTargetingsSortedByStatus(fixturesAbtasty)
 

--- a/src/shared/utils/data-manager.ts
+++ b/src/shared/utils/data-manager.ts
@@ -5,10 +5,10 @@ import { Data, TestsSortedByStatus, TargetingsSortedByStatus, FormattedData } fr
  */
 export default class DataManager {
 	/**
-     * Get formatted data
-     * @param {Object} data Data
-     * @returns {Object} Formatted data
-     */
+	 * Get formatted data
+	 * @param {Object} data Data
+	 * @returns {Object} Formatted data
+	 */
 	getFormattedData(data: Data): FormattedData {
 		return {
 			testsSortedByStatus: this.getTestsSortedByStatus(data),

--- a/src/shared/utils/data-manager.ts
+++ b/src/shared/utils/data-manager.ts
@@ -23,13 +23,13 @@ export default class DataManager {
 	getTestsSortedByStatus(data: Data): TestsSortedByStatus {
 		return {
 			accepted: Object.keys(data.results)
-				.filter((id: string) => data.results[id].status === 'accepted')
+				.filter((id: string) => data.results[id].status === 'accepted' && data.results[id].type !== 'mastersegment')
 				.map((id: string) => {
 					data.results[id].key = id
 					return data.results[id]
 				}),
 			rejected: Object.keys(data.results)
-				.filter((id: string) => data.results[id].status !== 'accepted')
+				.filter((id: string) => data.results[id].status !== 'accepted' && data.results[id].type !== 'mastersegment')
 				.map((id: string) => {
 					data.results[id].key = id
 					return data.results[id]


### PR DESCRIPTION
## 1.1.1

### New features

- Add parent ID when test has one

### Updates

- Hide tests with type `mastersegment` in the list and the badge counter
- Fix indent